### PR TITLE
Fixed output on diff command

### DIFF
--- a/src/MageConfigSync/Command/DiffCommand.php
+++ b/src/MageConfigSync/Command/DiffCommand.php
@@ -74,13 +74,14 @@ class DiffCommand extends Command
                 foreach ($diff as $scope => $scope_data) {
                     foreach ($scope_data as $key => $value) {
                         $diff_count++;
-                        $output->writeln(
+                        $diff_message = sprintf(
                             "%s/%s is different (File: '%s', DB: '%s')",
                             $scope,
                             $key,
                             $file_data[$scope][$key],
                             $db_data[$scope][$key]
                         );
+                        $output->writeln($diff_message);
                     }
                 }
 


### PR DESCRIPTION
The output on diff command always returned "%s/%s is different (File: '%s', DB: '%s')", because the string didnt get parsed.
Added $diff_message variable containing formatted message which gets printed then
