### PR TITLE
Implement deleting entries with load

### DIFF
--- a/src/MageConfigSync/Command/LoadCommand.php
+++ b/src/MageConfigSync/Command/LoadCommand.php
@@ -67,7 +67,11 @@ class LoadCommand extends Command
                 foreach ($scope_data as $path => $value) {
                     $scope_data = ConfigYaml::extractFromScopeKey($scope_key);
 
-                    $affected_rows = $config_adapter->setValue($path, $value, $scope_data['scope'], $scope_data['scope_id']);
+                    if ($value !== null) {
+                        $affected_rows = $config_adapter->setValue($path, $value, $scope_data['scope'], $scope_data['scope_id']);
+                    } else {
+                        $affected_rows = $config_adapter->deleteValue($path, $scope_data['scope'], $scope_data['scope_id']);
+                    }
 
                     if ($affected_rows > 0) {
                         $line = sprintf(

--- a/src/MageConfigSync/Magento/ConfigurationAdapter.php
+++ b/src/MageConfigSync/Magento/ConfigurationAdapter.php
@@ -45,6 +45,26 @@ class ConfigurationAdapter
 
     /**
      * @param $path
+     * @param $scope
+     * @param $scope_id
+     *
+     * @return int Number of affected rows
+     */
+    public function deleteValue($path, $scope, $scope_id)
+    {
+        $write = $this->_magento->getDatabaseWriteConnection();
+        return $write->delete(
+            $this->_table_name,
+            array(
+                'scope = ?'    => $scope,
+                'scope_id = ?' => $scope_id,
+                'path = ?'     => $path
+            )
+        );
+    }
+
+    /**
+     * @param $path
      * @return array
      */
     public function getValue($path)


### PR DESCRIPTION
Magento treats NULL entries in configuration as existing values and does
not fall back to using configuration from a higher scope. In most cases,
this is not the intended behaviour. Therefore, if a value is null,
delete it from configuration instead of saving a null. This still allows
saving empty configuration values by passing in an empty string.