### PR TITLE
Add required autoloader file for Magento 2

### DIFF
--- a/bin/mageconfigsync
+++ b/bin/mageconfigsync
@@ -2,6 +2,7 @@
 <?php
 $autoload_files = array(
     __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../../../app/autoload.php',
     __DIR__ . '/../../../../vendor/autoload.php'
 );
 


### PR DESCRIPTION
We need to add also this autoloader for Magento 2.
Without it we will receive exception that:
"Use of undefined constant BP - assumed 'BP' in /var/www/html/vendor/punkstar/mageconfigsync/src/MageConfigSync/Magento2.php on line 168
"

Was tested on Magento 2.1.2
